### PR TITLE
Add download instructions for Google Colab in tutorial 5

### DIFF
--- a/05 - GWpy Examples.ipynb
+++ b/05 - GWpy Examples.ipynb
@@ -47,6 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#! wget http://gwosc.org/archive/data/O3b_4KHZ_R1/1263534080/H-H1_GWOSC_O3b_4KHZ_R1-1264312320-4096.hdf5\n",
     "#! pip install -q 'gwpy==3.0.10'"
    ]
   },


### PR DESCRIPTION
This PR adds the code to download the file needed in tutorial 5 when using Google Colab (as it's done in other tutorials).