### PR TITLE
Update to gwpy to 3.0.13

### DIFF
--- a/05 - GWpy Examples.ipynb
+++ b/05 - GWpy Examples.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "#! wget http://gwosc.org/archive/data/O3b_4KHZ_R1/1263534080/H-H1_GWOSC_O3b_4KHZ_R1-1264312320-4096.hdf5\n",
-    "#! pip install -q 'gwpy==3.0.10'"
+    "#! pip install -q 'gwpy==3.0.13'"
    ]
   },
   {
@@ -77,7 +77,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.0.10\n"
+      "3.0.13\n"
      ]
     }
    ],

--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,5 @@ dependencies:
   - h5py=3.12.1
   - matplotlib=3.9.2
   - scipy=1.14.1
-  - gwpy=3.0.10
+  - gwpy=3.0.13
   - codespell=2.3.0


### PR DESCRIPTION
This PR tackles #8 by updating to [gwpy 3.0.13](https://gitlab.com/gwpy/gwpy/-/releases/v3.0.13). Closes #8.